### PR TITLE
Release

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,33 @@
+name: Integration Tests
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  integration-test:
+    name: integration-tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: "go.mod"
+          cache: true
+
+      - name: Set up Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_wrapper: false
+
+      - name: Run integration tests
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        run: make test TEST_ID=ci-${{ github.run_id }}-${{ github.run_attempt }}

--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,10 @@ pkg/
 # Go workspace file
 go.work
 go.work.sum
+
+# Terraform files
+*.tfstate
+*.tfstate.backup
+.terraformrc-test
+test/**/.terraform/
+test/**/.terraform.lock.hcl

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ GOFMT_FILES?=$$(find . -name '*.go')
 PKG_NAME=tigris
 VERSION?=$(shell git describe --tags --always)
 INCLUDE_VERSION_IN_FILENAME?=false
+TEST_ID?=t-$(shell date +%s | tail -c 8)
 
 default: build
 
@@ -56,6 +57,14 @@ vet:
 fmt:
 	gofmt -w $(GOFMT_FILES)
 
+fmtcheck:
+	@gofmt_files=$$(gofmt -l $(GOFMT_FILES)); \
+	if [ -n "$${gofmt_files}" ]; then \
+		echo "Go source files require formatting with gofmt:"; \
+		echo "$${gofmt_files}"; \
+		exit 1; \
+	fi
+
 golangci-lint:
 	@golangci-lint run ./internal/... --config .golintci.yml
 
@@ -63,7 +72,11 @@ tools:
 	@echo "==> Installing development tooling..."
 	go generate -tags tools tools/tools.go
 
+test: build
+	@echo "==> Running integration tests with TEST_ID=$(TEST_ID)..."
+	@TEST_ID=$(TEST_ID) bash scripts/run-tests.sh
+
 docs: tools
 	@sh -c "'$(CURDIR)/scripts/generate-docs.sh'"
 
-.PHONY: build install lint terraform-provider-lint vet fmt golangci-lint tools
+.PHONY: build install lint terraform-provider-lint vet fmt fmtcheck golangci-lint tools test

--- a/README.md
+++ b/README.md
@@ -21,7 +21,13 @@ provider "tigris" {
 }
 
 resource "tigris_bucket" "example_bucket" {
-  bucket = "my-custom-bucket"
+  bucket               = "my-custom-bucket"
+  default_storage_tier = "STANDARD"
+
+  location {
+    type    = "single"
+    regions = ["sjc"]
+  }
 }
 
 resource "tigris_bucket_public_access" "example_bucket_public_access" {
@@ -36,13 +42,30 @@ resource "tigris_bucket_website_config" "example_website_config" {
 }
 
 resource "tigris_bucket_shadow_config" "example_shadow_config" {
-  bucket                = tigris_bucket.example_bucket.bucket
-  shadow_bucket         = "my-custom-bucket-shadow"
-  shadow_access_key     = "your-shadow-bucket-access-key"
-  shadow_secret_key     = "your-shadow-bucket-secret-key"
-  shadow_region         = "us-west-2"
-  shadown_endpoint      = "https://s3.us-west-2.amazonaws.com"
-  shadow_write_through  = true
+  bucket               = tigris_bucket.example_bucket.bucket
+  shadow_bucket        = "my-custom-bucket-shadow"
+  shadow_access_key    = "your-shadow-bucket-access-key"
+  shadow_secret_key    = "your-shadow-bucket-secret-key"
+  shadow_region        = "us-west-2"
+  shadow_endpoint      = "https://s3.us-west-2.amazonaws.com"
+  shadow_write_through = true
+}
+
+# Snapshots and Forks
+resource "tigris_bucket" "snapshot_bucket" {
+  bucket          = "my-snapshot-bucket"
+  enable_snapshot = true
+}
+
+resource "tigris_bucket_snapshot" "example_snapshot" {
+  source_bucket = tigris_bucket.snapshot_bucket.bucket
+  snapshot_name = "my-snapshot"
+}
+
+resource "tigris_bucket_fork" "example_fork" {
+  bucket                      = "my-forked-bucket"
+  fork_source_bucket          = tigris_bucket.snapshot_bucket.bucket
+  fork_source_bucket_snapshot = tigris_bucket_snapshot.example_snapshot.snapshot_version
 }
 ```
 
@@ -86,10 +109,22 @@ The tigris_bucket resource creates and manages a Tigris bucket. This resource su
 #### Configuration
 
 - bucket: (Required) The name of the Tigris bucket.
+- location: (Optional) The location configuration for the bucket. Controls data placement and replication.
+  - type: (Required) The location type: `global`, `multi`, `dual`, or `single`.
+  - regions: (Optional) The region codes. For `multi`: `usa` or `eur`. For `single`/`dual`: specific region codes like `sjc`, `iad`, `ams`, etc.
+- default_storage_tier: (Optional) The default storage tier for objects in the bucket. Possible values: `STANDARD`, `STANDARD_IA`, `GLACIER`, `GLACIER_IR`. Cannot be changed after creation.
+- enable_snapshot: (Optional) Enable snapshots for this bucket. Defaults to `false`. Cannot be changed after creation.
 
 ```hcl
 resource "tigris_bucket" "example_bucket" {
-  bucket = "my-custom-bucket"
+  bucket               = "my-custom-bucket"
+  default_storage_tier = "STANDARD_IA"
+  enable_snapshot      = true
+
+  location {
+    type    = "single"
+    regions = ["sjc"]
+  }
 }
 ```
 
@@ -176,7 +211,103 @@ resource "tigris_bucket_shadow_config" "example_shadow_config" {
 }
 ```
 
+### tigris_bucket_snapshot
+
+The tigris_bucket_snapshot resource creates a point-in-time snapshot of a Tigris bucket. The source bucket must have snapshots enabled (`enable_snapshot = true`).
+
+> **Note:** Snapshots cannot be deleted via the API. Destroying this resource will only remove it from Terraform state.
+
+This resource supports the following actions:
+
+- Create: Creates a new snapshot of the source bucket.
+- Read: Retrieves information about the snapshot.
+- Delete: Removes the snapshot from Terraform state (no API deletion).
+- Import: Imports an existing snapshot using the format `{source_bucket}:{snapshot_version}:{snapshot_name}`.
+
+#### Configuration
+
+- source_bucket: (Required) The name of the source bucket to snapshot.
+- snapshot_name: (Required) The name for the snapshot.
+- snapshot_version: (Computed) The version identifier of the snapshot, returned by the API.
+- snapshot_created_at: (Computed) The timestamp when the snapshot was created.
+
+```hcl
+resource "tigris_bucket_snapshot" "example" {
+  source_bucket = tigris_bucket.snapshot_bucket.bucket
+  snapshot_name = "my-snapshot"
+}
+```
+
+### tigris_bucket_fork
+
+The tigris_bucket_fork resource creates a new bucket as a fork of an existing bucket, optionally from a specific snapshot. A forked bucket is a regular bucket that starts with the data from the source.
+
+This resource supports the following actions:
+
+- Create: Creates a new bucket forked from the source bucket.
+- Read: Retrieves information about the forked bucket and its fork metadata.
+- Delete: Deletes the forked bucket.
+- Import: Imports an existing forked bucket into Terraform's state.
+
+#### Configuration
+
+- bucket: (Required) The name of the new forked bucket.
+- fork_source_bucket: (Required) The name of the source bucket to fork from.
+- fork_source_bucket_snapshot: (Optional) The snapshot version to fork from. If not specified, forks from the current state.
+- fork_created_at: (Computed) The timestamp when the fork was created.
+
+```hcl
+resource "tigris_bucket_fork" "example" {
+  bucket                      = "my-forked-bucket"
+  fork_source_bucket          = "my-source-bucket"
+  fork_source_bucket_snapshot = tigris_bucket_snapshot.example.snapshot_version
+}
+```
+
 ## Developing
+
+### Local Development
+
+1. Build and install the provider:
+
+```shell
+make build    # builds the binary
+make install  # installs to $GOPATH/bin
+```
+
+2. Create a `~/.terraformrc` file to tell Terraform to use your local build:
+
+```hcl
+provider_installation {
+  dev_overrides {
+    "tigrisdata/tigris" = "<output of go env GOPATH>/bin"
+  }
+  direct {}
+}
+```
+
+3. Set your Tigris credentials:
+
+```shell
+export AWS_ACCESS_KEY_ID="your-access-key"
+export AWS_SECRET_ACCESS_KEY="your-secret-key"
+```
+
+4. Run Terraform against the example configurations in `examples/resources/`. With `dev_overrides` configured, skip `terraform init` and run directly:
+
+```shell
+cd examples/resources/tigris_bucket
+terraform plan
+terraform apply
+```
+
+### Useful Make Targets
+
+- `make vet` - Run static analysis
+- `make fmtcheck` - Check code formatting
+- `make fmt` - Auto-format code
+- `make lint` - Run full linting (requires `make tools` first)
+- `make docs` - Regenerate documentation
 
 ### Documentation
 

--- a/examples/resources/tigris_bucket/resource.tf
+++ b/examples/resources/tigris_bucket/resource.tf
@@ -1,3 +1,35 @@
-resource "tigris_bucket" "example_bucket" {
-  bucket = "my-custom-bucket"
+# Create a global bucket (default)
+resource "tigris_bucket" "global_bucket" {
+  bucket = "my-global-bucket"
+}
+
+# Create a bucket in a single region
+resource "tigris_bucket" "regional_bucket" {
+  bucket               = "my-regional-bucket"
+  default_storage_tier = "STANDARD_IA"
+
+  location {
+    type    = "single"
+    regions = ["sjc"]
+  }
+}
+
+# Create a bucket with multi-region replication
+resource "tigris_bucket" "multi_region_bucket" {
+  bucket = "my-us-bucket"
+
+  location {
+    type    = "multi"
+    regions = ["usa"]
+  }
+}
+
+# Create a bucket with dual-region replication
+resource "tigris_bucket" "dual_region_bucket" {
+  bucket = "my-eu-bucket"
+
+  location {
+    type    = "dual"
+    regions = ["fra", "ams"]
+  }
 }

--- a/examples/resources/tigris_bucket_fork/resource.tf
+++ b/examples/resources/tigris_bucket_fork/resource.tf
@@ -1,0 +1,24 @@
+# Source bucket with snapshots enabled
+resource "tigris_bucket" "source" {
+  bucket          = "my-source-bucket"
+  enable_snapshot = true
+}
+
+# Create a snapshot to fork from
+resource "tigris_bucket_snapshot" "example" {
+  source_bucket = tigris_bucket.source.bucket
+  snapshot_name = "pre-fork-snapshot"
+}
+
+# Create a fork of an existing bucket
+resource "tigris_bucket_fork" "example" {
+  bucket             = "my-forked-bucket"
+  fork_source_bucket = tigris_bucket.source.bucket
+}
+
+# Create a fork from a specific snapshot
+resource "tigris_bucket_fork" "from_snapshot" {
+  bucket                      = "my-forked-from-snapshot"
+  fork_source_bucket          = tigris_bucket.source.bucket
+  fork_source_bucket_snapshot = tigris_bucket_snapshot.example.snapshot_version
+}

--- a/examples/resources/tigris_bucket_snapshot/resource.tf
+++ b/examples/resources/tigris_bucket_snapshot/resource.tf
@@ -1,0 +1,11 @@
+# Create a bucket with snapshots enabled
+resource "tigris_bucket" "source" {
+  bucket          = "my-source-bucket"
+  enable_snapshot = true
+}
+
+# Create a snapshot of the bucket
+resource "tigris_bucket_snapshot" "example" {
+  source_bucket = tigris_bucket.source.bucket
+  snapshot_name = "my-snapshot"
+}

--- a/internal/client.go
+++ b/internal/client.go
@@ -11,6 +11,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -37,6 +38,15 @@ const (
 	HeaderAmzIdentityId        = "S3-Identity-Id"
 	HeaderAmzAcl               = "X-Amz-Acl"
 	HeaderAmzPublicListObjects = "X-Amz-Acl-Public-List-Objects-Enabled"
+
+	// Tigris-specific headers for bucket configuration.
+	HeaderAmzStorageClass          = "X-Amz-Storage-Class"
+	HeaderTigrisRegions            = "X-Tigris-Regions"
+	HeaderTigrisEnableSnapshot     = "X-Tigris-Enable-Snapshot"
+	HeaderTigrisForkSourceBucket   = "X-Tigris-Fork-Source-Bucket"
+	HeaderTigrisForkSourceSnapshot = "X-Tigris-Fork-Source-Bucket-Snapshot"
+	HeaderTigrisSnapshot           = "X-Tigris-Snapshot"
+	HeaderTigrisSnapshotVersion    = "X-Tigris-Snapshot-Version"
 )
 
 type Client struct {
@@ -85,9 +95,36 @@ func (c *Client) CreateBucket(ctx context.Context, input *types.BucketUpdateInpu
 		return err
 	}
 
+	var opts []func(*s3.Options)
+
+	// Add storage class header for default tier.
+	if input.DefaultStorageTier != nil {
+		opts = append(opts, withHeader(HeaderAmzStorageClass, string(*input.DefaultStorageTier)))
+	}
+
+	// Add regions header (only when not global).
+	if len(input.LocationRegions) > 0 {
+		opts = append(opts, withHeader(HeaderTigrisRegions, strings.Join(input.LocationRegions, ",")))
+	}
+
+	// Add snapshot enable header.
+	if input.EnableSnapshot != nil && *input.EnableSnapshot {
+		opts = append(opts, withHeader(HeaderTigrisEnableSnapshot, "true"))
+	}
+
+	// Add fork source bucket header.
+	if input.ForkSourceBucket != nil {
+		opts = append(opts, withHeader(HeaderTigrisForkSourceBucket, *input.ForkSourceBucket))
+	}
+
+	// Add fork source snapshot header.
+	if input.ForkSourceSnapshot != nil {
+		opts = append(opts, withHeader(HeaderTigrisForkSourceSnapshot, *input.ForkSourceSnapshot))
+	}
+
 	_, err := c.s3Client.CreateBucket(ctx, &s3.CreateBucketInput{
 		Bucket: aws.String(input.Bucket),
-	})
+	}, opts...)
 
 	return err
 }
@@ -108,6 +145,12 @@ func (c *Client) UpdateBucket(ctx context.Context, input *types.BucketUpdateInpu
 	// Set the shadow bucket configuration if it's provided
 	if input.Shadow != nil {
 		upReq.Shadow = input.Shadow
+	}
+
+	// Set the object regions if provided (for location updates).
+	if input.LocationRegions != nil {
+		regions := strings.Join(input.LocationRegions, ",")
+		upReq.ObjectRegions = &regions
 	}
 
 	body, err := json.Marshal(upReq)
@@ -203,36 +246,91 @@ func (c *Client) GetBucketMetadata(ctx context.Context, bucketName string) (*typ
 	return &metadata, nil
 }
 
-func (c *Client) FindBucketWithRetry(ctx context.Context, bucketName string) (bool, error) {
-	maxRetries := 5
-	backoffDelay := 3 * time.Second
-	maxBackoffDelay := 60 * time.Second
-
-	var exists bool
-
-	for i := 0; i < maxRetries; i++ {
-		exists, err := c.HeadBucket(ctx, bucketName)
-		if err != nil {
-			return false, err
-		}
-
-		// Retry the request if the bucket does not exist
-		if !exists {
-			// Exponential backoff before retrying
-			time.Sleep(backoffDelay)
-			backoffDelay *= 2 // Double the delay for each retry
-			if backoffDelay > maxBackoffDelay {
-				backoffDelay = maxBackoffDelay
-			}
-
-			continue
-		}
-
-		// Break out of the loop if the request was successful
-		break
+func (c *Client) CreateSnapshot(ctx context.Context, sourceBucket, snapshotName string) (string, error) {
+	// Build the header value for snapshot creation.
+	headerValue := "true"
+	if snapshotName != "" {
+		headerValue = fmt.Sprintf("true; name=%s", snapshotName)
 	}
 
-	return exists, nil
+	// Use raw HTTP request to capture the x-tigris-snapshot-version response header.
+	req, err := http.NewRequestWithContext(ctx, http.MethodPut, c.bucketURL(sourceBucket, nil), nil)
+	if err != nil {
+		return "", fmt.Errorf("failed to create snapshot request: %w", err)
+	}
+
+	req.Header.Set(HeaderTigrisSnapshot, headerValue)
+
+	//nolint:contextcheck
+	resp, err := c.doRequestWithRetry(req)
+	if err != nil {
+		return "", fmt.Errorf("failed to create snapshot: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
+		return "", fmt.Errorf("snapshot creation failed with code: %d", resp.StatusCode)
+	}
+
+	version := resp.Header.Get(HeaderTigrisSnapshotVersion)
+	if version == "" {
+		return "", fmt.Errorf("snapshot version not returned in response headers")
+	}
+
+	return version, nil
+}
+
+func (c *Client) ListSnapshots(ctx context.Context, sourceBucket string) ([]types.SnapshotInfo, error) {
+	// Use S3 ListBuckets with X-Tigris-Snapshot header set to the bucket name.
+	output, err := c.s3Client.ListBuckets(ctx, &s3.ListBucketsInput{},
+		withHeader(HeaderTigrisSnapshot, sourceBucket),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list snapshots: %w", err)
+	}
+
+	snapshots := make([]types.SnapshotInfo, 0, len(output.Buckets))
+	for _, b := range output.Buckets {
+		// The Name field from ListBuckets has the format: "{version}; name={snapshot_name}"
+		version, name := parseSnapshotBucketName(aws.ToString(b.Name))
+		info := types.SnapshotInfo{
+			Version: version,
+			Name:    name,
+		}
+		if b.CreationDate != nil {
+			info.CreatedAt = b.CreationDate.Format(time.RFC3339)
+		}
+		snapshots = append(snapshots, info)
+	}
+
+	return snapshots, nil
+}
+
+// parseSnapshotBucketName parses the snapshot Name field from the ListBuckets API.
+// The format is "{version}; name={snapshot_name}". If the format doesn't match,
+// the entire string is returned as the version with an empty name.
+func parseSnapshotBucketName(raw string) (version, name string) {
+	const sep = "; name="
+	idx := strings.Index(raw, sep)
+	if idx < 0 {
+		return raw, ""
+	}
+	return raw[:idx], raw[idx+len(sep):]
+}
+
+func (c *Client) GetSnapshotByName(ctx context.Context, sourceBucket, name string) (*types.SnapshotInfo, error) {
+	snapshots, err := c.ListSnapshots(ctx, sourceBucket)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, s := range snapshots {
+		if s.Name == name {
+			return &s, nil
+		}
+	}
+
+	return nil, fmt.Errorf("snapshot %q not found for bucket %q", name, sourceBucket)
 }
 
 func (c *Client) doRequestWithRetry(req *http.Request) (*http.Response, error) {

--- a/internal/names/names.go
+++ b/internal/names/names.go
@@ -12,4 +12,20 @@ const (
 	AttrShadowBucket       = "shadow_bucket"
 	AttrShadowEndpoint     = "shadow_endpoint"
 	AttrShadowWriteThrough = "shadow_write_through"
+
+	// Bucket location and storage tier attributes.
+	AttrLocation           = "location"
+	AttrLocationType       = "type"
+	AttrLocationRegions    = "regions"
+	AttrDefaultStorageTier = "default_storage_tier"
+
+	// Snapshot and fork attributes.
+	AttrEnableSnapshot           = "enable_snapshot"
+	AttrSourceBucket             = "source_bucket"
+	AttrSnapshotName             = "snapshot_name"
+	AttrSnapshotVersion          = "snapshot_version"
+	AttrSnapshotCreatedAt        = "snapshot_created_at"
+	AttrForkSourceBucket         = "fork_source_bucket"
+	AttrForkSourceBucketSnapshot = "fork_source_bucket_snapshot"
+	AttrForkCreatedAt            = "fork_created_at"
 )

--- a/internal/provider.go
+++ b/internal/provider.go
@@ -35,6 +35,8 @@ func Provider() *schema.Provider {
 			"tigris_bucket_public_access":  resourceTigrisBucketPublicAccess(),
 			"tigris_bucket_website_config": resourceTigrisBucketWebsiteConfig(),
 			"tigris_bucket_shadow_config":  resourceTigrisBucketShadowConfig(),
+			"tigris_bucket_snapshot":       resourceTigrisBucketSnapshot(),
+			"tigris_bucket_fork":           resourceTigrisBucketFork(),
 		},
 		ConfigureFunc: providerConfigure,
 	}

--- a/internal/resource_bucket.go
+++ b/internal/resource_bucket.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/tigrisdata/terraform-provider-tigris/internal/names"
 	"github.com/tigrisdata/terraform-provider-tigris/internal/types"
 )
@@ -39,6 +40,46 @@ func resourceTigrisBucket() *schema.Resource {
 				Required:    true,
 				Description: "The name of the Tigris bucket.",
 			},
+			names.AttrLocation: {
+				Type:        schema.TypeList,
+				Optional:    true,
+				Computed:    true,
+				MaxItems:    1,
+				Description: "The location configuration for the bucket. Controls data placement and replication.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						names.AttrLocationType: {
+							Type:         schema.TypeString,
+							Required:     true,
+							Description:  "The location type: global, multi, dual, or single.",
+							ValidateFunc: validation.StringInSlice(locationTypeValues(), false),
+						},
+						names.AttrLocationRegions: {
+							Type:        schema.TypeSet,
+							Optional:    true,
+							Description: "The region codes. For multi: usa or eur. For single/dual: specific region codes like sjc, iad, ams, etc.",
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
+						},
+					},
+				},
+			},
+			names.AttrDefaultStorageTier: {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ForceNew:     true,
+				Description:  "The default storage tier for objects in the bucket: STANDARD, STANDARD_IA, GLACIER, or GLACIER_IR.",
+				ValidateFunc: validation.StringInSlice(storageTierValues(), false),
+			},
+			names.AttrEnableSnapshot: {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     false,
+				ForceNew:    true,
+				Description: "Enable snapshots for this bucket. Cannot be changed after creation.",
+			},
 		},
 	}
 }
@@ -53,6 +94,38 @@ func resourceBucketCreate(ctx context.Context, d *schema.ResourceData, meta inte
 
 	input := &types.BucketUpdateInput{
 		Bucket: bucketName,
+	}
+
+	// Handle location.
+	if v, ok := d.GetOk(names.AttrLocation); ok {
+		locationList := v.([]interface{})
+		if len(locationList) > 0 {
+			locationMap := locationList[0].(map[string]interface{})
+			locationType := locationMap[names.AttrLocationType].(string)
+			regionsRaw := locationMap[names.AttrLocationRegions].(*schema.Set).List()
+			regions := make([]string, len(regionsRaw))
+			for i, r := range regionsRaw {
+				regions[i] = r.(string)
+			}
+			if err := validateLocation(locationType, regions); err != nil {
+				return diag.FromErr(err)
+			}
+			if types.LocationType(locationType) != types.LocationTypeGlobal {
+				input.LocationRegions = regions
+			}
+		}
+	}
+
+	// Handle default storage tier.
+	if v, ok := d.GetOk(names.AttrDefaultStorageTier); ok {
+		tier := types.StorageTier(v.(string))
+		input.DefaultStorageTier = &tier
+	}
+
+	// Handle enable snapshot.
+	if v, ok := d.GetOk(names.AttrEnableSnapshot); ok && v.(bool) {
+		enableSnapshot := true
+		input.EnableSnapshot = &enableSnapshot
 	}
 
 	tflog.Info(ctx, "Creating bucket", map[string]interface{}{
@@ -83,6 +156,9 @@ func resourceBucketRead(ctx context.Context, d *schema.ResourceData, meta interf
 	})
 
 	exists, err := svc.HeadBucket(ctx, bucketName)
+	if err != nil {
+		return diag.FromErr(fmt.Errorf("unable to read bucket, %w", err))
+	}
 	if !exists {
 		tflog.Warn(ctx, "Bucket not found, removing from state", map[string]interface{}{
 			"bucket_name": bucketName,
@@ -91,17 +167,75 @@ func resourceBucketRead(ctx context.Context, d *schema.ResourceData, meta interf
 		d.SetId("")
 		return nil
 	}
-	if err != nil {
-		return diag.FromErr(fmt.Errorf("unable to read bucket, %w", err))
-	}
 
 	d.Set(names.AttrBucket, bucketName)
+
+	// Fetch metadata to read location and storage tier.
+	metadata, err := svc.GetBucketMetadata(ctx, bucketName)
+	if err != nil {
+		return diag.FromErr(fmt.Errorf("unable to read bucket metadata, %w", err))
+	}
+
+	// Set storage tier.
+	d.Set(names.AttrDefaultStorageTier, metadata.GetStorageClass())
+
+	// Set location.
+	locationType, regions := metadata.GetLocationTypeAndRegions()
+	locationBlock := map[string]interface{}{
+		names.AttrLocationType:    string(locationType),
+		names.AttrLocationRegions: regions,
+	}
+	d.Set(names.AttrLocation, []interface{}{locationBlock})
+
+	// Set enable snapshot.
+	d.Set(names.AttrEnableSnapshot, metadata.IsSnapshotEnabled())
 
 	return nil
 }
 
 func resourceBucketUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	// This resource cannot be updated
+	svc := meta.(*Client)
+
+	bucketName := d.Id()
+
+	input := &types.BucketUpdateInput{
+		Bucket: bucketName,
+	}
+	needsUpdate := false
+
+	if d.HasChange(names.AttrLocation) {
+		v := d.Get(names.AttrLocation)
+		locationList := v.([]interface{})
+		if len(locationList) > 0 {
+			locationMap := locationList[0].(map[string]interface{})
+			locationType := locationMap[names.AttrLocationType].(string)
+			regionsRaw := locationMap[names.AttrLocationRegions].(*schema.Set).List()
+			regions := make([]string, len(regionsRaw))
+			for i, r := range regionsRaw {
+				regions[i] = r.(string)
+			}
+			if err := validateLocation(locationType, regions); err != nil {
+				return diag.FromErr(err)
+			}
+			if types.LocationType(locationType) == types.LocationTypeGlobal {
+				input.LocationRegions = []string{}
+			} else {
+				input.LocationRegions = regions
+			}
+			needsUpdate = true
+		}
+	}
+
+	if needsUpdate {
+		tflog.Info(ctx, "Updating bucket", map[string]interface{}{
+			"bucket_name": bucketName,
+		})
+
+		if err := svc.UpdateBucket(ctx, input); err != nil {
+			return diag.FromErr(fmt.Errorf("unable to update bucket, %w", err))
+		}
+	}
+
 	return resourceBucketRead(ctx, d, meta)
 }
 
@@ -141,4 +275,69 @@ func validBucketName(value string) error {
 	}
 
 	return nil
+}
+
+func locationTypeValues() []string {
+	var lt types.LocationType
+	values := make([]string, 0, len(lt.Values()))
+	for _, v := range lt.Values() {
+		values = append(values, string(v))
+	}
+	return values
+}
+
+func storageTierValues() []string {
+	var st types.StorageTier
+	values := make([]string, 0, len(st.Values()))
+	for _, v := range st.Values() {
+		values = append(values, string(v))
+	}
+	return values
+}
+
+func validateLocation(locationType string, regions []string) error {
+	lt := types.LocationType(locationType)
+
+	switch lt {
+	case types.LocationTypeGlobal:
+		if len(regions) > 0 {
+			return fmt.Errorf("regions must not be specified for global location type")
+		}
+	case types.LocationTypeMulti:
+		if len(regions) != 1 {
+			return fmt.Errorf("exactly one geography must be specified for multi location type (usa or eur)")
+		}
+		if !stringInSlice(regions[0], types.ValidMultiRegions) {
+			return fmt.Errorf("invalid multi-region geography %q, must be one of: %s", regions[0], strings.Join(types.ValidMultiRegions, ", "))
+		}
+	case types.LocationTypeDual:
+		if len(regions) < 2 {
+			return fmt.Errorf("at least two regions must be specified for dual location type")
+		}
+		for _, r := range regions {
+			if !stringInSlice(r, types.ValidSingleRegions) {
+				return fmt.Errorf("invalid region %q for dual location type, must be one of: %s", r, strings.Join(types.ValidSingleRegions, ", "))
+			}
+		}
+	case types.LocationTypeSingle:
+		if len(regions) != 1 {
+			return fmt.Errorf("exactly one region must be specified for single location type")
+		}
+		if !stringInSlice(regions[0], types.ValidSingleRegions) {
+			return fmt.Errorf("invalid region %q for single location type, must be one of: %s", regions[0], strings.Join(types.ValidSingleRegions, ", "))
+		}
+	default:
+		return fmt.Errorf("invalid location type %q", locationType)
+	}
+
+	return nil
+}
+
+func stringInSlice(s string, list []string) bool {
+	for _, v := range list {
+		if v == s {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/resource_bucket_fork.go
+++ b/internal/resource_bucket_fork.go
@@ -1,0 +1,157 @@
+package internal
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/tigrisdata/terraform-provider-tigris/internal/names"
+	"github.com/tigrisdata/terraform-provider-tigris/internal/types"
+)
+
+func resourceTigrisBucketFork() *schema.Resource {
+	return &schema.Resource{
+		Description:          "Provides a Tigris bucket fork resource. This creates a new bucket as a fork of an existing bucket, optionally from a specific snapshot.",
+		CreateWithoutTimeout: resourceBucketForkCreate,
+		ReadWithoutTimeout:   resourceBucketForkRead,
+		DeleteWithoutTimeout: resourceBucketForkDelete,
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(20 * time.Minute),
+			Read:   schema.DefaultTimeout(20 * time.Minute),
+			Delete: schema.DefaultTimeout(60 * time.Minute),
+		},
+
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Schema: map[string]*schema.Schema{
+			names.AttrBucket: {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "The name of the new forked bucket.",
+			},
+			names.AttrForkSourceBucket: {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "The name of the source bucket to fork from.",
+			},
+			names.AttrForkSourceBucketSnapshot: {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Description: "The snapshot version to fork from. If not specified, forks from the current state.",
+			},
+			names.AttrForkCreatedAt: {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The timestamp when the fork was created.",
+			},
+		},
+	}
+}
+
+func resourceBucketForkCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	svc := meta.(*Client)
+
+	bucketName := d.Get(names.AttrBucket).(string)
+	forkSourceBucket := d.Get(names.AttrForkSourceBucket).(string)
+
+	if err := validBucketName(bucketName); err != nil {
+		return diag.FromErr(fmt.Errorf("invalid bucket name, %w", err))
+	}
+
+	input := &types.BucketUpdateInput{
+		Bucket:           bucketName,
+		ForkSourceBucket: &forkSourceBucket,
+	}
+
+	if v, ok := d.GetOk(names.AttrForkSourceBucketSnapshot); ok {
+		snapshot := v.(string)
+		input.ForkSourceSnapshot = &snapshot
+	}
+
+	tflog.Info(ctx, "Creating bucket fork", map[string]interface{}{
+		"bucket_name":        bucketName,
+		"fork_source_bucket": forkSourceBucket,
+	})
+
+	err := svc.CreateBucket(ctx, input)
+	if err != nil {
+		return diag.FromErr(fmt.Errorf("unable to create bucket fork, %w", err))
+	}
+
+	tflog.Info(ctx, "Bucket fork created successfully", map[string]interface{}{
+		"bucket_name": bucketName,
+	})
+
+	d.SetId(bucketName)
+
+	return resourceBucketForkRead(ctx, d, meta)
+}
+
+func resourceBucketForkRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	svc := meta.(*Client)
+
+	bucketName := d.Id()
+
+	tflog.Info(ctx, "Reading bucket fork", map[string]interface{}{
+		"bucket_name": bucketName,
+	})
+
+	exists, err := svc.HeadBucket(ctx, bucketName)
+	if err != nil {
+		return diag.FromErr(fmt.Errorf("unable to read forked bucket, %w", err))
+	}
+	if !exists {
+		tflog.Warn(ctx, "Forked bucket not found, removing from state", map[string]interface{}{
+			"bucket_name": bucketName,
+		})
+		d.SetId("")
+		return nil
+	}
+
+	d.Set(names.AttrBucket, bucketName)
+
+	// Fetch metadata to get fork info.
+	metadata, err := svc.GetBucketMetadata(ctx, bucketName)
+	if err != nil {
+		return diag.FromErr(fmt.Errorf("unable to read bucket metadata, %w", err))
+	}
+
+	if metadata.ForkInfo != nil && len(metadata.ForkInfo.Parents) > 0 {
+		parent := metadata.ForkInfo.Parents[0]
+		d.Set(names.AttrForkSourceBucket, parent.BucketName)
+		if parent.Snapshot != "" {
+			d.Set(names.AttrForkSourceBucketSnapshot, parent.Snapshot)
+		}
+		d.Set(names.AttrForkCreatedAt, parent.ForkCreatedAt)
+	}
+
+	return nil
+}
+
+func resourceBucketForkDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	svc := meta.(*Client)
+
+	bucketName := d.Id()
+
+	tflog.Info(ctx, "Deleting forked bucket", map[string]interface{}{
+		"bucket_name": bucketName,
+	})
+
+	// Forks are regular buckets, so delete normally.
+	err := svc.DeleteBucket(ctx, bucketName)
+	if err != nil {
+		return diag.FromErr(fmt.Errorf("unable to delete forked bucket, %w", err))
+	}
+
+	d.SetId("")
+	return nil
+}

--- a/internal/resource_bucket_public_access.go
+++ b/internal/resource_bucket_public_access.go
@@ -99,6 +99,9 @@ func resourceBucketPublicAccessRead(ctx context.Context, d *schema.ResourceData,
 	})
 
 	exists, err := svc.HeadBucket(ctx, bucketName)
+	if err != nil {
+		return diag.FromErr(fmt.Errorf("unable to read bucket, %w", err))
+	}
 	if !exists {
 		tflog.Warn(ctx, "Bucket not found, removing from state", map[string]interface{}{
 			"bucket_name": bucketName,
@@ -106,9 +109,6 @@ func resourceBucketPublicAccessRead(ctx context.Context, d *schema.ResourceData,
 
 		d.SetId("")
 		return nil
-	}
-	if err != nil {
-		return diag.FromErr(fmt.Errorf("unable to read bucket, %w", err))
 	}
 
 	d.Set(names.AttrBucket, bucketName)
@@ -186,7 +186,7 @@ func resourceBucketPublicAccessUpdate(ctx context.Context, d *schema.ResourceDat
 		}
 	}
 
-	return resourceBucketRead(ctx, d, meta)
+	return resourceBucketPublicAccessRead(ctx, d, meta)
 }
 
 func resourceBucketPublicAccessDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {

--- a/internal/resource_bucket_snapshot.go
+++ b/internal/resource_bucket_snapshot.go
@@ -1,0 +1,172 @@
+package internal
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/tigrisdata/terraform-provider-tigris/internal/names"
+)
+
+func resourceTigrisBucketSnapshot() *schema.Resource {
+	return &schema.Resource{
+		Description:          "Provides a Tigris bucket snapshot resource. This creates a point-in-time snapshot of a Tigris bucket.",
+		CreateWithoutTimeout: resourceBucketSnapshotCreate,
+		ReadWithoutTimeout:   resourceBucketSnapshotRead,
+		DeleteWithoutTimeout: resourceBucketSnapshotDelete,
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(20 * time.Minute),
+			Read:   schema.DefaultTimeout(20 * time.Minute),
+			Delete: schema.DefaultTimeout(20 * time.Minute),
+		},
+
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceBucketSnapshotImport,
+		},
+
+		Schema: map[string]*schema.Schema{
+			names.AttrSourceBucket: {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "The name of the source bucket to snapshot.",
+			},
+			names.AttrSnapshotName: {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "The name for the snapshot.",
+			},
+			names.AttrSnapshotVersion: {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The version identifier of the snapshot.",
+			},
+			names.AttrSnapshotCreatedAt: {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The timestamp when the snapshot was created.",
+			},
+		},
+	}
+}
+
+func resourceBucketSnapshotCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	svc := meta.(*Client)
+
+	sourceBucket := d.Get(names.AttrSourceBucket).(string)
+	snapshotName := d.Get(names.AttrSnapshotName).(string)
+
+	tflog.Info(ctx, "Creating bucket snapshot", map[string]interface{}{
+		"source_bucket": sourceBucket,
+		"snapshot_name": snapshotName,
+	})
+
+	snapshotVersion, err := svc.CreateSnapshot(ctx, sourceBucket, snapshotName)
+	if err != nil {
+		return diag.FromErr(fmt.Errorf("unable to create snapshot, %w", err))
+	}
+
+	tflog.Info(ctx, "Bucket snapshot created successfully", map[string]interface{}{
+		"source_bucket":    sourceBucket,
+		"snapshot_version": snapshotVersion,
+	})
+
+	d.SetId(fmt.Sprintf("%s:%s", sourceBucket, snapshotVersion))
+	d.Set(names.AttrSnapshotVersion, snapshotVersion)
+
+	return resourceBucketSnapshotRead(ctx, d, meta)
+}
+
+func resourceBucketSnapshotRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	svc := meta.(*Client)
+
+	sourceBucket, snapshotVersion, err := parseBucketSnapshotID(d.Id())
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	tflog.Info(ctx, "Reading bucket snapshot", map[string]interface{}{
+		"source_bucket":    sourceBucket,
+		"snapshot_version": snapshotVersion,
+	})
+
+	// Check if the source bucket still exists.
+	exists, err := svc.HeadBucket(ctx, sourceBucket)
+	if err != nil {
+		return diag.FromErr(fmt.Errorf("unable to check source bucket %q: %w", sourceBucket, err))
+	}
+	if !exists {
+		tflog.Warn(ctx, "Source bucket not found, removing snapshot from state", map[string]interface{}{
+			"source_bucket": sourceBucket,
+		})
+		d.SetId("")
+		return nil
+	}
+
+	d.Set(names.AttrSourceBucket, sourceBucket)
+	d.Set(names.AttrSnapshotVersion, snapshotVersion)
+
+	// Look up the snapshot by name to populate metadata.
+	snapshotName := d.Get(names.AttrSnapshotName).(string)
+	if snapshotName != "" {
+		snapshot, err := svc.GetSnapshotByName(ctx, sourceBucket, snapshotName)
+		if err != nil {
+			return diag.FromErr(fmt.Errorf("unable to read snapshot %q for bucket %q: %w", snapshotName, sourceBucket, err))
+		}
+		d.Set(names.AttrSnapshotName, snapshot.Name)
+		d.Set(names.AttrSnapshotCreatedAt, snapshot.CreatedAt)
+	}
+
+	return nil
+}
+
+func resourceBucketSnapshotDelete(_ context.Context, d *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// There is no snapshot deletion API. Remove from state only.
+	d.SetId("")
+	return nil
+}
+
+func resourceBucketSnapshotImport(_ context.Context, d *schema.ResourceData, _ interface{}) ([]*schema.ResourceData, error) {
+	sourceBucket, snapshotVersion, snapshotName, err := parseBucketSnapshotImportID(d.Id())
+	if err != nil {
+		return nil, err
+	}
+
+	d.SetId(fmt.Sprintf("%s:%s", sourceBucket, snapshotVersion))
+	d.Set(names.AttrSourceBucket, sourceBucket)
+	d.Set(names.AttrSnapshotVersion, snapshotVersion)
+	d.Set(names.AttrSnapshotName, snapshotName)
+
+	return []*schema.ResourceData{d}, nil
+}
+
+func parseBucketSnapshotID(id string) (string, string, error) {
+	// Split into exactly 2 parts: bucket and version.
+	// Use the first colon as the delimiter since bucket names cannot contain colons,
+	// but snapshot versions might (e.g. RFC 3339 timestamps).
+	idx := strings.IndexByte(id, ':')
+	if idx <= 0 || idx >= len(id)-1 {
+		return "", "", fmt.Errorf("invalid snapshot ID format %q, expected {source_bucket}:{snapshot_version}", id)
+	}
+	return id[:idx], id[idx+1:], nil
+}
+
+func parseBucketSnapshotImportID(id string) (string, string, string, error) {
+	// Format: {source_bucket}:{snapshot_version}:{snapshot_name}
+	// Bucket names cannot contain colons, and snapshot names are user-provided simple strings.
+	// Snapshot versions may contain colons (e.g. RFC 3339 timestamps), so we split on
+	// the first colon (bucket) and last colon (snapshot name), leaving everything in
+	// between as the version.
+	firstColon := strings.IndexByte(id, ':')
+	lastColon := strings.LastIndexByte(id, ':')
+	if firstColon <= 0 || lastColon <= firstColon || lastColon >= len(id)-1 {
+		return "", "", "", fmt.Errorf("invalid snapshot import ID format %q, expected {source_bucket}:{snapshot_version}:{snapshot_name}", id)
+	}
+	return id[:firstColon], id[firstColon+1 : lastColon], id[lastColon+1:], nil
+}

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -1,5 +1,7 @@
 package types
 
+import "strings"
+
 type BucketCannedACL string
 
 // Enum values for BucketCannedACL.
@@ -15,13 +17,68 @@ func (BucketCannedACL) Values() []BucketCannedACL {
 	}
 }
 
+// StorageTier represents the default storage tier for a bucket.
+type StorageTier string
+
+const (
+	StorageTierStandard   StorageTier = "STANDARD"
+	StorageTierStandardIA StorageTier = "STANDARD_IA"
+	StorageTierGlacier    StorageTier = "GLACIER"
+	StorageTierGlacierIR  StorageTier = "GLACIER_IR"
+)
+
+func (StorageTier) Values() []StorageTier {
+	return []StorageTier{
+		StorageTierStandard,
+		StorageTierStandardIA,
+		StorageTierGlacier,
+		StorageTierGlacierIR,
+	}
+}
+
+// LocationType represents the bucket location type.
+type LocationType string
+
+const (
+	LocationTypeGlobal LocationType = "global"
+	LocationTypeMulti  LocationType = "multi"
+	LocationTypeDual   LocationType = "dual"
+	LocationTypeSingle LocationType = "single"
+)
+
+func (LocationType) Values() []LocationType {
+	return []LocationType{
+		LocationTypeGlobal,
+		LocationTypeMulti,
+		LocationTypeDual,
+		LocationTypeSingle,
+	}
+}
+
+// Valid region values.
+var (
+	ValidMultiRegions  = []string{"usa", "eur"}
+	ValidSingleRegions = []string{"ams", "fra", "gru", "iad", "jnb", "lhr", "nrt", "ord", "sin", "sjc", "syd"}
+)
+
+// BucketType represents the type of a Tigris bucket.
+const (
+	// BucketTypeDefault is a standard bucket without snapshots.
+	BucketTypeDefault = 0
+	// BucketTypeSnapshot is a bucket with snapshots enabled.
+	BucketTypeSnapshot = 1
+)
+
 type BucketMetadata struct {
 	Name          string               `json:"name"`
 	CacheControl  string               `json:"cache_control"`
 	ObjectRegions string               `json:"object_regions"`
+	StorageClass  string               `json:"storage_class"`
+	Type          int                  `json:"type"`
 	MD            *BucketMD            `json:"md"`
 	Shadow        *BucketShadowConfig  `json:"shadow_bucket"`
 	Website       *BucketWebsiteConfig `json:"website"`
+	ForkInfo      *ForkInfo            `json:"ForkInfo"`
 }
 
 type BucketMD struct {
@@ -49,6 +106,57 @@ func (b *BucketMetadata) GetPublicObjectsListEnabled() bool {
 	return false
 }
 
+// GetStorageClass returns the storage class, defaulting to STANDARD.
+func (b *BucketMetadata) GetStorageClass() string {
+	if b.StorageClass == "" {
+		return string(StorageTierStandard)
+	}
+	return b.StorageClass
+}
+
+// GetLocationTypeAndRegions parses object_regions into a LocationType and region list.
+func (b *BucketMetadata) GetLocationTypeAndRegions() (LocationType, []string) {
+	if b.ObjectRegions == "" {
+		return LocationTypeGlobal, nil
+	}
+
+	regions := strings.Split(b.ObjectRegions, ",")
+	for i := range regions {
+		regions[i] = strings.TrimSpace(regions[i])
+	}
+
+	// Filter out empty strings
+	filtered := make([]string, 0, len(regions))
+	for _, r := range regions {
+		if r != "" {
+			filtered = append(filtered, r)
+		}
+	}
+	regions = filtered
+
+	if len(regions) == 0 {
+		return LocationTypeGlobal, nil
+	}
+
+	if len(regions) == 1 {
+		// Check if it's a multi-region value
+		for _, mr := range ValidMultiRegions {
+			if regions[0] == mr {
+				return LocationTypeMulti, regions
+			}
+		}
+		return LocationTypeSingle, regions
+	}
+
+	// 2+ regions is dual location type
+	return LocationTypeDual, regions
+}
+
+// IsSnapshotEnabled returns true if snapshots are enabled for this bucket.
+func (b *BucketMetadata) IsSnapshotEnabled() bool {
+	return b.Type == BucketTypeSnapshot
+}
+
 type BucketWebsiteConfig struct {
 	DomainName string `json:"domain_name"`
 }
@@ -62,7 +170,28 @@ type BucketShadowConfig struct {
 	WriteThrough bool   `json:"write_through"`
 }
 
-// BucketUpdateInput is the input for the UpdateBucket function.
+// SnapshotInfo represents a single snapshot.
+type SnapshotInfo struct {
+	Version   string
+	Name      string
+	CreatedAt string
+}
+
+// ForkParentInfo represents a parent bucket in fork info.
+type ForkParentInfo struct {
+	BucketName        string `json:"BucketName"`
+	ForkCreatedAt     string `json:"ForkCreatedAt"`
+	Snapshot          string `json:"Snapshot"`
+	SnapshotCreatedAt string `json:"SnapshotCreatedAt"`
+}
+
+// ForkInfo represents the fork information from bucket metadata.
+type ForkInfo struct {
+	HasChildren bool             `json:"HasChildren"`
+	Parents     []ForkParentInfo `json:"Parents"`
+}
+
+// BucketUpdateInput is the input for the CreateBucket and UpdateBucket functions.
 type BucketUpdateInput struct {
 	// The name of the bucket to create.
 	Bucket string
@@ -78,12 +207,28 @@ type BucketUpdateInput struct {
 
 	// The shadow bucket configuration for the bucket.
 	Shadow *BucketShadowConfig
+
+	// The default storage tier for the bucket (set at creation).
+	DefaultStorageTier *StorageTier
+
+	// The location regions for the bucket.
+	LocationRegions []string
+
+	// Whether to enable snapshots (set at creation, cannot be changed).
+	EnableSnapshot *bool
+
+	// The source bucket for creating a fork.
+	ForkSourceBucket *string
+
+	// The snapshot version to fork from.
+	ForkSourceSnapshot *string
 }
 
 // BucketUpdateRequest is the request body for the UpdateBucket API.
 type BucketUpdateRequest struct {
-	Website *BucketWebsiteConfig `json:"website"`
-	Shadow  *BucketShadowConfig  `json:"shadow_bucket"`
+	Website       *BucketWebsiteConfig `json:"website,omitempty"`
+	Shadow        *BucketShadowConfig  `json:"shadow_bucket,omitempty"`
+	ObjectRegions *string              `json:"object_regions,omitempty"`
 }
 
 type BucketUpdateResponse struct {

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+PROVIDER_BIN_DIR="${REPO_ROOT}"
+TEST_ID="${TEST_ID:-t-$(date +%s | tail -c 7)}"
+
+SUITES=(
+  bucket-basic
+  bucket-location
+  bucket-snapshot
+  bucket-fork
+  bucket-update
+  bucket-public-access
+)
+FAILED_SUITES=()
+
+# Create a temporary .terraformrc with dev_overrides
+export TF_CLI_CONFIG_FILE="${REPO_ROOT}/.terraformrc-test"
+cat > "$TF_CLI_CONFIG_FILE" <<EOF
+provider_installation {
+  dev_overrides {
+    "tigrisdata/tigris" = "${PROVIDER_BIN_DIR}"
+  }
+  direct {}
+}
+EOF
+
+cleanup() {
+  rm -f "$TF_CLI_CONFIG_FILE"
+}
+trap cleanup EXIT
+
+echo "==> Using TEST_ID=${TEST_ID}"
+echo ""
+
+for suite in "${SUITES[@]}"; do
+  echo "==> Testing ${suite}..."
+  suite_dir="${REPO_ROOT}/test/${suite}"
+  cd "$suite_dir"
+
+  # Clean up any leftover state from previous runs to avoid stale resource conflicts
+  rm -rf .terraform .terraform.lock.hcl terraform.tfstate terraform.tfstate.backup
+
+  # With dev_overrides, init still runs but skips provider download
+  terraform init -input=false > /dev/null 2>&1 || true
+
+  # Apply
+  if terraform apply -auto-approve -input=false -var "test_id=${TEST_ID}"; then
+    echo "==> PASS: ${suite}"
+  else
+    FAILED_SUITES+=("$suite")
+    echo "==> FAIL: ${suite}"
+  fi
+
+  # Always destroy to clean up resources
+  terraform destroy -auto-approve -input=false -var "test_id=${TEST_ID}" 2>/dev/null || true
+
+  echo ""
+done
+
+# Report results
+echo "==> Results:"
+echo "   Total:  ${#SUITES[@]}"
+echo "   Failed: ${#FAILED_SUITES[@]}"
+
+if [ ${#FAILED_SUITES[@]} -gt 0 ]; then
+  echo "   Failed suites: ${FAILED_SUITES[*]}"
+  exit 1
+fi
+
+echo "   All suites passed."

--- a/templates/resources/bucket_fork.md.tmpl
+++ b/templates/resources/bucket_fork.md.tmpl
@@ -1,0 +1,27 @@
+---
+page_title: "{{.Name}} {{.Type}} - {{.RenderedProviderName}}"
+subcategory: ""
+description: |-
+{{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
+---
+
+# {{.Name}} ({{.Type}})
+
+{{ .Description | trimspace }}
+
+~> **Note:** A forked bucket is a regular bucket. Destroying this resource will delete the bucket.
+
+{{ if .HasExample -}}
+## Example Usage
+
+{{codefile "terraform" .ExampleFile}}
+{{- end }}
+{{ .SchemaMarkdown | trimspace }}
+
+{{ if .HasImport -}}
+## Import
+
+Import is supported using the following syntax:
+
+{{codefile "shell" .ImportFile}}
+{{- end }}

--- a/templates/resources/bucket_snapshot.md.tmpl
+++ b/templates/resources/bucket_snapshot.md.tmpl
@@ -1,0 +1,29 @@
+---
+page_title: "{{.Name}} {{.Type}} - {{.RenderedProviderName}}"
+subcategory: ""
+description: |-
+{{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
+---
+
+# {{.Name}} ({{.Type}})
+
+{{ .Description | trimspace }}
+
+~> **Note:** The source bucket must have snapshots enabled (`enable_snapshot = true`) before snapshots can be created.
+
+~> **Note:** Snapshots cannot be deleted via the API. Destroying this resource will only remove it from state.
+
+{{ if .HasExample -}}
+## Example Usage
+
+{{codefile "terraform" .ExampleFile}}
+{{- end }}
+{{ .SchemaMarkdown | trimspace }}
+
+{{ if .HasImport -}}
+## Import
+
+Import is supported using the following syntax. The ID format is `{source_bucket}:{snapshot_version}:{snapshot_name}`.
+
+{{codefile "shell" .ImportFile}}
+{{- end }}

--- a/test/bucket-basic/main.tf
+++ b/test/bucket-basic/main.tf
@@ -1,0 +1,37 @@
+terraform {
+  required_providers {
+    tigris = {
+      source = "tigrisdata/tigris"
+    }
+  }
+}
+
+provider "tigris" {}
+
+variable "test_id" {
+  type    = string
+  default = "t"
+}
+
+# Basic bucket with defaults
+resource "tigris_bucket" "basic" {
+  bucket = "${var.test_id}-basic-bucket"
+}
+
+# Bucket with a non-default storage tier
+resource "tigris_bucket" "standard_ia" {
+  bucket               = "${var.test_id}-standard-ia-bucket"
+  default_storage_tier = "STANDARD_IA"
+}
+
+output "basic_bucket" {
+  value = tigris_bucket.basic.bucket
+}
+
+output "standard_ia_bucket" {
+  value = tigris_bucket.standard_ia.bucket
+}
+
+output "standard_ia_storage_tier" {
+  value = tigris_bucket.standard_ia.default_storage_tier
+}

--- a/test/bucket-fork/main.tf
+++ b/test/bucket-fork/main.tf
@@ -1,0 +1,34 @@
+terraform {
+  required_providers {
+    tigris = {
+      source = "tigrisdata/tigris"
+    }
+  }
+}
+
+provider "tigris" {}
+
+variable "test_id" {
+  type    = string
+  default = "t"
+}
+
+# Source bucket to fork from (must have snapshots enabled)
+resource "tigris_bucket" "source" {
+  bucket          = "${var.test_id}-fork-src-bucket"
+  enable_snapshot = true
+}
+
+# Fork the source bucket (direct fork, no snapshot)
+resource "tigris_bucket_fork" "fork" {
+  bucket             = "${var.test_id}-forked-bucket"
+  fork_source_bucket = tigris_bucket.source.bucket
+}
+
+output "fork_bucket" {
+  value = tigris_bucket_fork.fork.bucket
+}
+
+output "fork_created_at" {
+  value = tigris_bucket_fork.fork.fork_created_at
+}

--- a/test/bucket-location/main.tf
+++ b/test/bucket-location/main.tf
@@ -1,0 +1,65 @@
+terraform {
+  required_providers {
+    tigris = {
+      source = "tigrisdata/tigris"
+    }
+  }
+}
+
+provider "tigris" {}
+
+variable "test_id" {
+  type    = string
+  default = "t"
+}
+
+# Global bucket (default behavior, no location block needed)
+resource "tigris_bucket" "global" {
+  bucket = "${var.test_id}-global-bucket"
+}
+
+# Single-region bucket
+resource "tigris_bucket" "single_region" {
+  bucket = "${var.test_id}-single-region-bucket"
+
+  location {
+    type    = "single"
+    regions = ["sjc"]
+  }
+}
+
+# Multi-region bucket
+resource "tigris_bucket" "multi_region" {
+  bucket = "${var.test_id}-multi-region-bucket"
+
+  location {
+    type    = "multi"
+    regions = ["usa"]
+  }
+}
+
+# Dual-region bucket
+resource "tigris_bucket" "dual_region" {
+  bucket = "${var.test_id}-dual-region-bucket"
+
+  location {
+    type    = "dual"
+    regions = ["fra", "ams"]
+  }
+}
+
+output "global_bucket" {
+  value = tigris_bucket.global.bucket
+}
+
+output "single_region_location" {
+  value = tigris_bucket.single_region.location
+}
+
+output "multi_region_location" {
+  value = tigris_bucket.multi_region.location
+}
+
+output "dual_region_location" {
+  value = tigris_bucket.dual_region.location
+}

--- a/test/bucket-public-access/main.tf
+++ b/test/bucket-public-access/main.tf
@@ -1,0 +1,32 @@
+terraform {
+  required_providers {
+    tigris = {
+      source = "tigrisdata/tigris"
+    }
+  }
+}
+
+provider "tigris" {}
+
+variable "test_id" {
+  type    = string
+  default = "t"
+}
+
+resource "tigris_bucket" "bucket" {
+  bucket = "${var.test_id}-pub-access-bucket"
+}
+
+resource "tigris_bucket_public_access" "public" {
+  bucket              = tigris_bucket.bucket.bucket
+  acl                 = "public-read"
+  public_list_objects = true
+}
+
+output "acl" {
+  value = tigris_bucket_public_access.public.acl
+}
+
+output "public_list_objects" {
+  value = tigris_bucket_public_access.public.public_list_objects
+}

--- a/test/bucket-snapshot/main.tf
+++ b/test/bucket-snapshot/main.tf
@@ -1,0 +1,45 @@
+terraform {
+  required_providers {
+    tigris = {
+      source = "tigrisdata/tigris"
+    }
+  }
+}
+
+provider "tigris" {}
+
+variable "test_id" {
+  type    = string
+  default = "t"
+}
+
+# Source bucket with snapshots enabled
+resource "tigris_bucket" "source" {
+  bucket          = "${var.test_id}-snapshot-src-bucket"
+  enable_snapshot = true
+}
+
+# Create a snapshot of the source bucket
+resource "tigris_bucket_snapshot" "snap" {
+  source_bucket = tigris_bucket.source.bucket
+  snapshot_name = "${var.test_id}-snapshot"
+}
+
+# Fork from the snapshot
+resource "tigris_bucket_fork" "from_snapshot" {
+  bucket                       = "${var.test_id}-fork-from-snap-bucket"
+  fork_source_bucket           = tigris_bucket.source.bucket
+  fork_source_bucket_snapshot  = tigris_bucket_snapshot.snap.snapshot_version
+}
+
+output "snapshot_version" {
+  value = tigris_bucket_snapshot.snap.snapshot_version
+}
+
+output "snapshot_created_at" {
+  value = tigris_bucket_snapshot.snap.snapshot_created_at
+}
+
+output "fork_from_snapshot_created_at" {
+  value = tigris_bucket_fork.from_snapshot.fork_created_at
+}

--- a/test/bucket-update/main.tf
+++ b/test/bucket-update/main.tf
@@ -1,0 +1,37 @@
+terraform {
+  required_providers {
+    tigris = {
+      source = "tigrisdata/tigris"
+    }
+  }
+}
+
+provider "tigris" {}
+
+variable "test_id" {
+  type    = string
+  default = "t"
+}
+
+# Bucket whose location can be updated in-place.
+#
+# To test the update path:
+#   1. Apply with the initial location (single region, sjc)
+#   2. Change the location block below (e.g. to multi-region "usa")
+#   3. Apply again and verify the update succeeds
+resource "tigris_bucket" "updatable" {
+  bucket = "${var.test_id}-updatable-bucket"
+
+  location {
+    type    = "single"
+    regions = ["sjc"]
+  }
+}
+
+output "bucket" {
+  value = tigris_bucket.updatable.bucket
+}
+
+output "location" {
+  value = tigris_bucket.updatable.location
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Extends bucket create/update behavior via new Tigris-specific headers and adds new snapshot/fork resources, which could impact real bucket provisioning/state if API/header semantics differ. CI now runs Terraform-based integration tests using live credentials, increasing exposure to flaky or destructive test failures if cleanup misses resources.
> 
> **Overview**
> **Adds new bucket capabilities and resources.** `tigris_bucket` now supports `location`, `default_storage_tier`, and `enable_snapshot`, including validation, state readback from bucket metadata, and in-place updates for `location`.
> 
> **Introduces snapshots and forks.** New `tigris_bucket_snapshot` resource creates snapshots (state-only delete, custom import format) and new `tigris_bucket_fork` resource creates forked buckets (optionally from a snapshot); the client adds the required request headers plus snapshot list/create helpers and fork metadata parsing.
> 
> **Adds integration test automation and updated docs/examples.** Adds a GitHub Actions workflow and `make test` runner that executes multiple Terraform test suites, updates `.gitignore`, and expands README/docs templates/examples for the new resources and arguments.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2ffc3eaa574875918a1cb24fd33f8f25950d8cd9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->