### PR TITLE
fix: remove .VERSION file before goreleaser to avoid dirty git state

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -31,6 +31,7 @@ jobs:
           if [ -f .VERSION ]; then
             echo "released=true" >> "$GITHUB_OUTPUT"
             echo "version=$(cat .VERSION)" >> "$GITHUB_OUTPUT"
+            rm .VERSION
           else
             echo "released=false" >> "$GITHUB_OUTPUT"
           fi


### PR DESCRIPTION
## Summary

GoReleaser refuses to build when the working directory has untracked files. The `.VERSION` file created by semantic-release during version detection was causing goreleaser to fail with "git is in a dirty state".

## Changes

Deletes the `.VERSION` file after reading it, so the git state is clean before goreleaser runs. This allows the release workflow to proceed without errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small CI workflow tweak that only deletes a temporary version file to prevent GoReleaser failures; no product code changes.
> 
> **Overview**
> Ensures the release workflow deletes the temporary `.VERSION` file after reading it in the "Check if a new release was created" step.
> 
> This prevents GoReleaser from seeing an untracked file and failing due to a dirty git working directory during releases.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3ce7c88088052de8c34c12f304adf43dfab7fc9b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->