### PR TITLE
Release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -31,6 +31,7 @@ jobs:
           if [ -f .VERSION ]; then
             echo "released=true" >> "$GITHUB_OUTPUT"
             echo "version=$(cat .VERSION)" >> "$GITHUB_OUTPUT"
+            rm .VERSION
           else
             echo "released=false" >> "$GITHUB_OUTPUT"
           fi


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk workflow tweak that only affects CI state between steps by deleting the `.VERSION` marker file after reading it.
> 
> **Overview**
> The release GitHub Actions workflow now deletes the `.VERSION` file after detecting and reading it in the “Check if a new release was created” step, preventing the release marker from persisting for later steps or future runs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 91715c750dfb12fbc85a1b3b8580373ded1bb783. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->