### PR TITLE
fix: return error after retry exhaustion and respect context cancellation

### DIFF
--- a/internal/client.go
+++ b/internal/client.go
@@ -366,10 +366,12 @@ func (c *Client) doRequestWithRetry(req *http.Request) (*http.Response, error) {
 			}
 
 			// Exponential backoff before retrying, respecting context cancellation
+			timer := time.NewTimer(backoffDelay)
 			select {
 			case <-req.Context().Done():
+				timer.Stop()
 				return nil, req.Context().Err()
-			case <-time.After(backoffDelay):
+			case <-timer.C:
 			}
 			backoffDelay *= 2 // Double the delay for each retry
 			if backoffDelay > maxBackoffDelay {

--- a/internal/client.go
+++ b/internal/client.go
@@ -50,12 +50,13 @@ const (
 )
 
 type Client struct {
-	cfg         aws.Config
-	signer      *v4.Signer
-	credentials aws.Credentials
-	endpoint    string
-	httpClient  *http.Client
-	s3Client    *s3.Client
+	cfg              aws.Config
+	signer           *v4.Signer
+	credentials      aws.Credentials
+	endpoint         string
+	httpClient       *http.Client
+	s3Client         *s3.Client
+	retryBaseDelay   time.Duration // initial backoff delay; 0 uses default (3s)
 }
 
 func NewClient(endpoint, accessKeyID, secretAccessKey string) (*Client, error) {
@@ -335,11 +336,13 @@ func (c *Client) GetSnapshotByName(ctx context.Context, sourceBucket, name strin
 
 func (c *Client) doRequestWithRetry(req *http.Request) (*http.Response, error) {
 	maxRetries := 5
-	backoffDelay := 3 * time.Second
-	maxBackoffDelay := 60 * time.Second
+	backoffDelay := c.retryBaseDelay
+	if backoffDelay == 0 {
+		backoffDelay = 3 * time.Second
+	}
+	maxBackoffDelay := 20 * backoffDelay
 
-	var resp *http.Response
-	var err error
+	var lastStatusCode int
 
 	for i := 0; i < maxRetries; i++ {
 		// Clone the request to avoid issues with mutated request objects
@@ -348,17 +351,26 @@ func (c *Client) doRequestWithRetry(req *http.Request) (*http.Response, error) {
 			return nil, fmt.Errorf("failed to clone request: %w", err)
 		}
 
-		resp, err = c.doSignedRequest(clonedReq)
+		resp, err := c.doSignedRequest(clonedReq)
 		if err != nil {
 			return nil, fmt.Errorf("failed to send request: %w", err)
 		}
 
 		// Check if the response status code indicates a server-side error (5xx)
 		if resp.StatusCode >= 500 {
+			lastStatusCode = resp.StatusCode
 			resp.Body.Close()
 
-			// Exponential backoff before retrying
-			time.Sleep(backoffDelay)
+			if i == maxRetries-1 {
+				break
+			}
+
+			// Exponential backoff before retrying, respecting context cancellation
+			select {
+			case <-req.Context().Done():
+				return nil, req.Context().Err()
+			case <-time.After(backoffDelay):
+			}
 			backoffDelay *= 2 // Double the delay for each retry
 			if backoffDelay > maxBackoffDelay {
 				backoffDelay = maxBackoffDelay
@@ -367,11 +379,10 @@ func (c *Client) doRequestWithRetry(req *http.Request) (*http.Response, error) {
 			continue
 		}
 
-		// Break out of the loop if the request was successful
-		break
+		return resp, nil
 	}
 
-	return resp, err
+	return nil, fmt.Errorf("request failed after %d retries with status %d", maxRetries, lastStatusCode)
 }
 
 func (c *Client) doSignedRequest(req *http.Request) (*http.Response, error) {
@@ -432,7 +443,7 @@ func (c *Client) signRequest(req *http.Request) error {
 	req.Header.Set(HeaderAmzContentSha, payloadHash)
 
 	// Sign the request using the signer
-	err := c.signer.SignHTTP(context.TODO(), c.credentials, req, payloadHash, "s3", DefaultRegion, now)
+	err := c.signer.SignHTTP(req.Context(), c.credentials, req, payloadHash, "s3", DefaultRegion, now)
 	if err != nil {
 		return fmt.Errorf("failed to sign request: %w", err)
 	}

--- a/internal/client.go
+++ b/internal/client.go
@@ -50,13 +50,13 @@ const (
 )
 
 type Client struct {
-	cfg              aws.Config
-	signer           *v4.Signer
-	credentials      aws.Credentials
-	endpoint         string
-	httpClient       *http.Client
-	s3Client         *s3.Client
-	retryBaseDelay   time.Duration // initial backoff delay; 0 uses default (3s)
+	cfg            aws.Config
+	signer         *v4.Signer
+	credentials    aws.Credentials
+	endpoint       string
+	httpClient     *http.Client
+	s3Client       *s3.Client
+	retryBaseDelay time.Duration // initial backoff delay; 0 uses default (3s)
 }
 
 func NewClient(endpoint, accessKeyID, secretAccessKey string) (*Client, error) {

--- a/internal/client_test.go
+++ b/internal/client_test.go
@@ -30,6 +30,13 @@ func newTestClient(t *testing.T, serverURL string) *Client {
 	}
 }
 
+func writeBody(t *testing.T, w http.ResponseWriter, body string) {
+	t.Helper()
+	if _, err := w.Write([]byte(body)); err != nil {
+		t.Errorf("failed to write response body: %v", err)
+	}
+}
+
 func TestDoRequestWithRetry_Success(t *testing.T) {
 	t.Parallel()
 
@@ -37,7 +44,7 @@ func TestDoRequestWithRetry_Success(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		calls.Add(1)
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(`OK`))
+		writeBody(t, w, "OK")
 	}))
 	defer srv.Close()
 
@@ -69,11 +76,11 @@ func TestDoRequestWithRetry_RetriesThenSucceeds(t *testing.T) {
 		n := calls.Add(1)
 		if n <= 2 {
 			w.WriteHeader(http.StatusInternalServerError)
-			w.Write([]byte(`error`))
+			writeBody(t, w, "error")
 			return
 		}
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(`OK`))
+		writeBody(t, w, "OK")
 	}))
 	defer srv.Close()
 
@@ -104,7 +111,7 @@ func TestDoRequestWithRetry_ExhaustsRetries(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		calls.Add(1)
 		w.WriteHeader(http.StatusBadGateway)
-		w.Write([]byte(`bad gateway`))
+		writeBody(t, w, "bad gateway")
 	}))
 	defer srv.Close()
 
@@ -114,7 +121,7 @@ func TestDoRequestWithRetry_ExhaustsRetries(t *testing.T) {
 		t.Fatalf("failed to create request: %v", err)
 	}
 
-	resp, err := client.doRequestWithRetry(req)
+	resp, err := client.doRequestWithRetry(req) //nolint:bodyclose // resp is nil on exhaustion
 	if err == nil {
 		t.Fatalf("expected error after retry exhaustion, got nil")
 	}
@@ -142,7 +149,7 @@ func TestDoRequestWithRetry_RespectsContextCancellation(t *testing.T) {
 		default:
 		}
 		w.WriteHeader(http.StatusInternalServerError)
-		w.Write([]byte(`error`))
+		writeBody(t, w, "error")
 	}))
 	defer srv.Close()
 
@@ -161,7 +168,7 @@ func TestDoRequestWithRetry_RespectsContextCancellation(t *testing.T) {
 		cancel()
 	}()
 
-	resp, err := client.doRequestWithRetry(req)
+	resp, err := client.doRequestWithRetry(req) //nolint:bodyclose // resp is nil on cancellation
 	if err == nil {
 		t.Fatalf("expected context cancellation error, got nil")
 	}
@@ -181,11 +188,11 @@ func TestDoRequestWithRetry_WithBody(t *testing.T) {
 		n := calls.Add(1)
 		if n <= 1 {
 			w.WriteHeader(http.StatusInternalServerError)
-			w.Write([]byte(`error`))
+			writeBody(t, w, "error")
 			return
 		}
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(`OK`))
+		writeBody(t, w, "OK")
 	}))
 	defer srv.Close()
 

--- a/internal/client_test.go
+++ b/internal/client_test.go
@@ -1,0 +1,211 @@
+package internal
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	v4 "github.com/aws/aws-sdk-go-v2/aws/signer/v4"
+)
+
+// newTestClient creates a Client that talks to the given test server
+// with minimal retry delay for fast tests.
+func newTestClient(t *testing.T, serverURL string) *Client {
+	t.Helper()
+	return &Client{
+		signer: v4.NewSigner(),
+		credentials: aws.Credentials{
+			AccessKeyID:     "test-key",
+			SecretAccessKey: "test-secret",
+		},
+		endpoint:       serverURL,
+		httpClient:     &http.Client{},
+		retryBaseDelay: 1 * time.Millisecond,
+	}
+}
+
+func TestDoRequestWithRetry_Success(t *testing.T) {
+	t.Parallel()
+
+	var calls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`OK`))
+	}))
+	defer srv.Close()
+
+	client := newTestClient(t, srv.URL)
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL+"/test", nil)
+	if err != nil {
+		t.Fatalf("failed to create request: %v", err)
+	}
+
+	resp, err := client.doRequestWithRetry(req)
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+	if calls.Load() != 1 {
+		t.Fatalf("expected 1 call, got %d", calls.Load())
+	}
+}
+
+func TestDoRequestWithRetry_RetriesThenSucceeds(t *testing.T) {
+	t.Parallel()
+
+	var calls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := calls.Add(1)
+		if n <= 2 {
+			w.WriteHeader(http.StatusInternalServerError)
+			w.Write([]byte(`error`))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`OK`))
+	}))
+	defer srv.Close()
+
+	client := newTestClient(t, srv.URL)
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL+"/test", nil)
+	if err != nil {
+		t.Fatalf("failed to create request: %v", err)
+	}
+
+	resp, err := client.doRequestWithRetry(req)
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+	if calls.Load() != 3 {
+		t.Fatalf("expected 3 calls (2 failures + 1 success), got %d", calls.Load())
+	}
+}
+
+func TestDoRequestWithRetry_ExhaustsRetries(t *testing.T) {
+	t.Parallel()
+
+	var calls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		w.WriteHeader(http.StatusBadGateway)
+		w.Write([]byte(`bad gateway`))
+	}))
+	defer srv.Close()
+
+	client := newTestClient(t, srv.URL)
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL+"/test", nil)
+	if err != nil {
+		t.Fatalf("failed to create request: %v", err)
+	}
+
+	resp, err := client.doRequestWithRetry(req)
+	if err == nil {
+		t.Fatalf("expected error after retry exhaustion, got nil")
+	}
+	if resp != nil {
+		t.Fatalf("expected nil response after retry exhaustion, got %v", resp)
+	}
+	if !strings.Contains(err.Error(), "failed after 5 retries") {
+		t.Fatalf("expected retry exhaustion error message, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "502") {
+		t.Fatalf("expected status code in error message, got: %v", err)
+	}
+	if calls.Load() != 5 {
+		t.Fatalf("expected 5 calls, got %d", calls.Load())
+	}
+}
+
+func TestDoRequestWithRetry_RespectsContextCancellation(t *testing.T) {
+	t.Parallel()
+
+	called := make(chan struct{}, 1)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case called <- struct{}{}:
+		default:
+		}
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte(`error`))
+	}))
+	defer srv.Close()
+
+	client := newTestClient(t, srv.URL)
+	// Use a longer backoff so the cancellation hits during the wait
+	client.retryBaseDelay = 5 * time.Second
+
+	ctx, cancel := context.WithCancel(context.Background())
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, srv.URL+"/test", nil)
+	if err != nil {
+		t.Fatalf("failed to create request: %v", err)
+	}
+
+	go func() {
+		<-called
+		cancel()
+	}()
+
+	resp, err := client.doRequestWithRetry(req)
+	if err == nil {
+		t.Fatalf("expected context cancellation error, got nil")
+	}
+	if resp != nil {
+		t.Fatalf("expected nil response on cancellation, got %v", resp)
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context.Canceled, got: %v", err)
+	}
+}
+
+func TestDoRequestWithRetry_WithBody(t *testing.T) {
+	t.Parallel()
+
+	var calls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := calls.Add(1)
+		if n <= 1 {
+			w.WriteHeader(http.StatusInternalServerError)
+			w.Write([]byte(`error`))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`OK`))
+	}))
+	defer srv.Close()
+
+	client := newTestClient(t, srv.URL)
+	body := strings.NewReader("test-body")
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, srv.URL+"/test", body)
+	if err != nil {
+		t.Fatalf("failed to create request: %v", err)
+	}
+
+	resp, err := client.doRequestWithRetry(req)
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+	if calls.Load() != 2 {
+		t.Fatalf("expected 2 calls (1 failure + 1 success), got %d", calls.Load())
+	}
+}


### PR DESCRIPTION
## Summary

- `doRequestWithRetry` returns a closed response body with nil error when all 5 retries exhaust on 5xx responses. Callers get confusing "read on closed body" errors instead of a clear retry failure message.
- Retry backoff uses `time.Sleep`, which ignores request context cancellation — Terraform timeouts are not respected during backoff.
- `signRequest` uses `context.TODO()` instead of the request's context.

## Changes

- Return an explicit error with status code after retry exhaustion instead of a closed response body
- Respect context cancellation during backoff with `select` on `req.Context().Done()`
- Use `req.Context()` in `signRequest` instead of `context.TODO()`
- Add `retryBaseDelay` field (zero-value preserves existing 3s default) so tests can use short backoff — test runtime dropped from ~45s to ~1.6s
- 5 tests covering: success, retry-then-succeed, exhaustion, context cancellation, and body replay on retry

## Test plan

- [x] `go test ./... -race` passes
- [x] All 5 retry tests pass in ~1.6s
- [x] Zero-value `retryBaseDelay` preserves existing production behaviour (3s initial, 60s max)
- [x] No changes to public API surface

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>