### PR TITLE
fix: add defer cancel() to context cancellation test

### DIFF
--- a/internal/client_test.go
+++ b/internal/client_test.go
@@ -158,6 +158,7 @@ func TestDoRequestWithRetry_RespectsContextCancellation(t *testing.T) {
 	client.retryBaseDelay = 5 * time.Second
 
 	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, srv.URL+"/test", nil)
 	if err != nil {
 		t.Fatalf("failed to create request: %v", err)


### PR DESCRIPTION
One-liner follow-up to #23 — adds `defer cancel()` to prevent a context leak in the cancellation test.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>