### PR TITLE
fix: default public_list_objects to false when metadata header is absent

### DIFF
--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -96,7 +96,7 @@ func (b *BucketMetadata) GetBucketCannedACL() BucketCannedACL {
 
 func (b *BucketMetadata) GetPublicObjectsListEnabled() bool {
 	if b.MD == nil || b.MD.PublicObjectsListEnabled == nil {
-		return true
+		return false
 	}
 
 	if *b.MD.PublicObjectsListEnabled == "true" {

--- a/test/bucket-public-access/main.tf
+++ b/test/bucket-public-access/main.tf
@@ -13,14 +13,24 @@ variable "test_id" {
   default = "t"
 }
 
-resource "tigris_bucket" "bucket" {
+resource "tigris_bucket" "public" {
   bucket = "${var.test_id}-pub-access-bucket"
 }
 
 resource "tigris_bucket_public_access" "public" {
-  bucket              = tigris_bucket.bucket.bucket
+  bucket              = tigris_bucket.public.bucket
   acl                 = "public-read"
   public_list_objects = true
+}
+
+resource "tigris_bucket" "private" {
+  bucket = "${var.test_id}-priv-access-bucket"
+}
+
+resource "tigris_bucket_public_access" "private" {
+  bucket              = tigris_bucket.private.bucket
+  acl                 = "private"
+  public_list_objects = false
 }
 
 output "acl" {
@@ -29,4 +39,12 @@ output "acl" {
 
 output "public_list_objects" {
   value = tigris_bucket_public_access.public.public_list_objects
+}
+
+output "private_acl" {
+  value = tigris_bucket_public_access.private.acl
+}
+
+output "private_public_list_objects" {
+  value = tigris_bucket_public_access.private.public_list_objects
 }


### PR DESCRIPTION
When using `tigris_bucket_public_access` with `acl = "private"` and `public_list_objects = false`, `terraform plan` reports perpetual drift:

```hcl
resource "tigris_bucket" "private" {
  bucket = "${var.test_id}-priv-access-bucket"
}

resource "tigris_bucket_public_access" "private" {
  bucket              = tigris_bucket.private.bucket
  acl                 = "private"
  public_list_objects = false
}
```

```
  # tigris_bucket_public_access.private will be updated in-place
  ~ resource "tigris_bucket_public_access" "private" {
        id                  = "drift-repro-c346a5-priv-access-bucket"
      ~ public_list_objects = true -> false
        # (2 unchanged attributes hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```

`GetPublicObjectsListEnabled()` in `internal/types/types.go` returns `true` when `MD.PublicObjectsListEnabled` is nil, which is what the metadata response gives for private buckets.

```diff
 func (b *BucketMetadata) GetPublicObjectsListEnabled() bool {
     if b.MD == nil || b.MD.PublicObjectsListEnabled == nil {
-        return true
+        return false
     }
     ...
 }
```

The new default matches the schema declaration in `internal/resource_bucket_public_access.go`:

```go
names.AttrPublicListObjects: {
    Type:        schema.TypeBool,
    Optional:    true,
    Default:     false,
    Description: "Whether to allow public listing of objects in the bucket.",
},
```

After this change, `terraform plan` against the same config reports:

```
No changes. Your infrastructure matches the configuration.
```
