### PR TITLE
Release

### DIFF
--- a/internal/client_test.go
+++ b/internal/client_test.go
@@ -158,6 +158,7 @@ func TestDoRequestWithRetry_RespectsContextCancellation(t *testing.T) {
 	client.retryBaseDelay = 5 * time.Second
 
 	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, srv.URL+"/test", nil)
 	if err != nil {
 		t.Fatalf("failed to create request: %v", err)

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -96,7 +96,7 @@ func (b *BucketMetadata) GetBucketCannedACL() BucketCannedACL {
 
 func (b *BucketMetadata) GetPublicObjectsListEnabled() bool {
 	if b.MD == nil || b.MD.PublicObjectsListEnabled == nil {
-		return true
+		return false
 	}
 
 	if *b.MD.PublicObjectsListEnabled == "true" {

--- a/test/bucket-public-access/main.tf
+++ b/test/bucket-public-access/main.tf
@@ -13,14 +13,24 @@ variable "test_id" {
   default = "t"
 }
 
-resource "tigris_bucket" "bucket" {
+resource "tigris_bucket" "public" {
   bucket = "${var.test_id}-pub-access-bucket"
 }
 
 resource "tigris_bucket_public_access" "public" {
-  bucket              = tigris_bucket.bucket.bucket
+  bucket              = tigris_bucket.public.bucket
   acl                 = "public-read"
   public_list_objects = true
+}
+
+resource "tigris_bucket" "private" {
+  bucket = "${var.test_id}-priv-access-bucket"
+}
+
+resource "tigris_bucket_public_access" "private" {
+  bucket              = tigris_bucket.private.bucket
+  acl                 = "private"
+  public_list_objects = false
 }
 
 output "acl" {
@@ -29,4 +39,12 @@ output "acl" {
 
 output "public_list_objects" {
   value = tigris_bucket_public_access.public.public_list_objects
+}
+
+output "private_acl" {
+  value = tigris_bucket_public_access.private.acl
+}
+
+output "private_public_list_objects" {
+  value = tigris_bucket_public_access.private.public_list_objects
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the default behavior of `GetPublicObjectsListEnabled` from enabled to disabled when metadata is missing, which can affect bucket access defaults and downstream Terraform/provider behavior.
> 
> **Overview**
> Adjusts bucket metadata handling so `GetPublicObjectsListEnabled()` now defaults to `false` when the header is absent (instead of implicitly enabling public listing).
> 
> Updates tests: ensures context cancellation in `TestDoRequestWithRetry_RespectsContextCancellation` always calls `cancel()` via `defer`, and expands the Terraform `bucket-public-access` test to cover both a *public* and an explicit *private* bucket public-access configuration with corresponding outputs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit df115b52a53e4680e632c414d7d68775a27f5144. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->